### PR TITLE
added a dot to the fpm call

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -40,5 +40,5 @@ build: template
 package: build
 	fpm -s dir -t $(PACKAGETYPE) -n "$(PACKAGENAME)" -v "$(VERSION)" -m "$(MAINTAINER)" --url "$(URL)" \
 		--description "$(DESCRIPTION)" $(DEPENDS) $(POSTINST) $(PREINST) $(POSTRM) $(PRERM) \
-		-a $(ARCH) -C $(PTMP)/build -p $(PTMP)/$(PACKAGENAME)_$(VERSION).$(PACKAGETYPE)
+		-a $(ARCH) -C $(PTMP)/build -p $(PTMP)/$(PACKAGENAME)_$(VERSION).$(PACKAGETYPE) .
 


### PR DESCRIPTION
I get the following error now

```
fpm -s dir -t deb -n "symfony_master" -v "2.1" -m "me myself <me@myself.com>" --url "" \
                --description "directly from symfony githib" -d php5-cli     \
                -a all -C /tmp/symfony_master/build -p /tmp/symfony_master/symfony_master_2.1.deb
No parameters given. You need to pass additional command arguments so that I know what you want to build packages from. For example, for '-s dir' you would pass a list of files and directories. For '-s gem' you would pass a one or more gems to package from. As a full example, this will make an rpm of the 'json' rubygem: `fpm -s gem -t rpm json` {"level":"warn"}
Fix the above problems, and you'll be rolling packages in no time! {"level":"fatal"}
```

If I add a dot at the end of that call, it seems to work and the installation afterwards as well

Not sure, if something changed in FPM or if I'm doing something wrong. 
According to gem I have fpm (0.4.9) installed
